### PR TITLE
migrate to requests module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # umdmusic-downloader
-Python script to download top billboard singles from www.umdmusic.com
 
-I used this to get the data I needed for a data visualization project on my blog at http://www.modestinsights.com/analyzing-the-billboard-hot-100/.  Great website for historical music chart data (was not able to find anything elsewhere, except possibly paying billboard.com).
+## Description
 
-One note - using the default python html parser did not work, but BeautifulSoup docs suggested using html5lib, which fixed the problem.
+Python script to download top billboard singles from www.umdmusic.com, a great website for historical music charts data.
+
+I used this to get the data I needed for a [data visualization project on my blog](http://www.modestinsights.com/analyzing-the-billboard-hot-100/).
+
+## Requirements
+    requests
+    html5lib
+    beautifulsoup4
+
+## How to run
+    python downloader.py

--- a/downloader.py
+++ b/downloader.py
@@ -1,52 +1,51 @@
-from bs4 import BeautifulSoup
-import urllib.request
 import re
 
+from bs4 import BeautifulSoup
+from requests import session
+
+
 def main():
-    request_path="http://www.umdmusic.com/default.asp?Lang=English&Chart=D"
+    s = session()
+    request_path = "http://www.umdmusic.com/default.asp?Lang=English&Chart=D"
     out_file = "us_billboard.psv"
-    f=open(out_file, 'a')
+    with open(out_file, 'a') as f:
+        while True:
+            print("Downloading data from: " + request_path)
+            html = s.get(request_path).content
+            soup = BeautifulSoup(html, "html5lib")
 
-    while request_path != "":
-        print("Downloading data from: " + request_path)
-        response = urllib.request.urlopen(request_path)
-        html = response.read()
-        soup = BeautifulSoup(html, "html5lib")
-        chart_date=""
+            # first find the link for the previous chart (since the date for the current chart is embedded in it)
+            previous_link = soup.find_all(href=re.compile("ChDate=\d+&ChMode=P"))
+            if len(previous_link) > 0:
+                request_path = previous_link[0]['href']
+                request_path = "http://www.umdmusic.com/" + request_path
+                m = re.match(".*ChDate=(\d+).*", request_path)
+                chart_date = m.group(1)
+            else:
+                break
 
-        #first find the link for the previous chart (since the date for the current chart is embedded in it)
-        previous_link=soup.find_all(href=re.compile("ChDate=\d+&ChMode=P"))
-        if len(previous_link) > 0:
-            request_path=previous_link[0]['href']
-            request_path="http://www.umdmusic.com/" + request_path
-            m=re.match(".*ChDate=(\d+).*",request_path)
-            chart_date=m.group(1)
-        else:
-            request_path=""
+            # use this comment text that appears in the html to guide us towards the main table body
+            main_table = soup.find_all(text=re.compile("Display Chart Table"))[0]
+            while main_table.name != "table":
+                main_table = main_table.next_element
 
-        #use this comment text that appears in the html to guide us towards the main table body
-        main_table=soup.find_all(text=re.compile("Display Chart Table"))[0]
-        while main_table.name != "table":
-            main_table = main_table.next_element
+            for row in main_table.tbody.children:
+                if row.name == "tr":
+                    past_first_cell = False
+                    for cell in row.children:
+                        if cell.name == "td":
+                            if len(cell.contents) == 1:
+                                f.write(cell.string.strip() + "|")
+                                past_first_cell = True
+                            elif len(cell.contents) == 3:
+                                # fix that lets us skip header rows
+                                if not past_first_cell:
+                                    break
+                                f.write(cell.contents[0].string.strip() + "|")
+                                f.write(cell.contents[2].string.strip() + "|")
+                    if past_first_cell:
+                        f.write(chart_date + "\n")
 
-        for row in main_table.tbody.children:
-            if row.name == "tr":
-                past_first_cell=False
-                for cell in row.children:
-                    if cell.name == "td":
-                        if len(cell.contents) == 1:
-                            f.write(cell.string.strip()+"|")
-                            past_first_cell=True
-                        elif len(cell.contents) == 3:
-                            #fix that lets us skip header rows
-                            if not(past_first_cell):
-                                break
-                            f.write(cell.contents[0].string.strip() + "|")
-                            f.write(cell.contents[2].string.strip() + "|")
-                if past_first_cell:
-                    f.write(chart_date + "\n")
 
-    f.close()
-
-if __name__=="__main__":
+if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Django==1.6.5
+# minimogrify==2.1.7
+requests==2.2.1
+# uWSGI==2.0.4
+django-config-url==0.1.1


### PR DESCRIPTION
# Description

`urllilb` is really slow and calls for unneeded information every call. Using `requests`, specifically setting up a `session`, allows the user to download the data 10 times faster. 
# Changes
- Implemented migration to `requests` module. 
- Reformatted file to be PEP8 compliant.
- Changed file handling to `with open`.
- Cleaned formatting in `readme`.
- Added a `requirements.txt` because all the cool kids have it.
